### PR TITLE
Use singleton to bind Announcement to the container

### DIFF
--- a/src/Package/PackageServiceProvider.php
+++ b/src/Package/PackageServiceProvider.php
@@ -40,7 +40,7 @@ class PackageServiceProvider extends ServiceProvider
     {
         $this->mergeConfigFrom(__DIR__.'/../config/config.php', $this->packageName);
 
-        $this->app['announce'] = $this->app->share(function ($app) {
+        $this->app->singleton('announce', function () {
             return new Announce();
         });
     }


### PR DESCRIPTION
In order to correctly bind `Announce` to the service container, this
commit add fixes the issue and will make it compatible with the latest
version of Laravel 5.